### PR TITLE
Allow baseline and energy configuration with DUNE defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(oscillation_analysis)
+
+find_package(ROOT REQUIRED COMPONENTS Core Graf Gpad)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(plot_probability plot_probability.cpp)
+target_include_directories(plot_probability PRIVATE ${ROOT_INCLUDE_DIRS})
+target_link_libraries(plot_probability ${ROOT_LIBRARIES})

--- a/Oscillation.h
+++ b/Oscillation.h
@@ -1,33 +1,116 @@
 #pragma once
+
 #include <array>
 #include <complex>
 #include <cmath>
 
-struct PMNSParams{ double th12,th23,th13,dm21,dm31,delta; };
-
-struct PMNS{
-  using C=std::complex<double>; using U3=std::array<std::array<C,3>,3>;
-  static U3 R12(double t){ U3 r{}; double c=std::cos(t),s=std::sin(t); r[0][0]=c;r[0][1]=s;r[1][0]=-s;r[1][1]=c;r[2][2]=1; return r; }
-  static U3 R23(double t){ U3 r{}; double c=std::cos(t),s=std::sin(t); r[0][0]=1;r[1][1]=c;r[1][2]=s;r[2][1]=-s;r[2][2]=c; return r; }
-  static U3 U13(double t,double d){ U3 r{}; double c=std::cos(t),s=std::sin(t); r[0][0]=c; r[0][2]=std::exp(C(0,-d))*s; r[1][1]=1; r[2][0]=-std::exp(C(0,d))*s; r[2][2]=c; return r; }
-  static U3 mul(const U3&a,const U3&b){ U3 r{}; for(int i=0;i<3;++i) for(int j=0;j<3;++j){ r[i][j]=0.0; for(int k=0;k<3;++k) r[i][j]+=a[i][k]*b[k][j]; } return r; }
-  static U3 build(double th12,double th23,double th13,double d){ return mul(R23(th23),mul(U13(th13,d),R12(th12))); }
+struct PMNSParams {
+    double th12;
+    double th23;
+    double th13;
+    double dm21;
+    double dm31;
+    double delta;
 };
 
-struct PMNSVacuum{
-  using C=std::complex<double>; using U3=std::array<std::array<C,3>,3>;
-  PMNSVacuum(PMNSParams p):p_(p){U_=PMNS::build(p_.th12,p_.th23,p_.th13,p_.delta);} PMNSParams p_; U3 U_;
-  double prob(int a,int b,double L,double E) const{
-    const double k=1.267;
-    const double dm21=p_.dm21, dm31=p_.dm31, dm32=dm31-dm21;
-    const double D21=k*dm21*L/E, D31=k*dm31*L/E, D32=k*dm32*L/E;
-    auto term=[&](int i,int j){ auto A=U_[a][i]*std::conj(U_[b][i])*std::conj(U_[a][j])*U_[b][j]; return std::make_pair(A.real(),A.imag()); };
-    double p=(a==b);
-    {
-      auto t31=term(2,0); p+=-4.0*t31.first*std::sin(D31)*std::sin(D31)+2.0*t31.second*std::sin(2.0*D31);
-      auto t32=term(2,1); p+=-4.0*t32.first*std::sin(D32)*std::sin(D32)+2.0*t32.second*std::sin(2.0*D32);
-      auto t21=term(1,0); p+=-4.0*t21.first*std::sin(D21)*std::sin(D21)+2.0*t21.second*std::sin(2.0*D21);
+struct PMNS {
+    using C = std::complex<double>;
+    using U3 = std::array<std::array<C, 3>, 3>;
+
+    static U3 R12(double t) {
+        U3 r{};
+        double c = std::cos(t), s = std::sin(t);
+        r[0][0] = c;
+        r[0][1] = s;
+        r[1][0] = -s;
+        r[1][1] = c;
+        r[2][2] = 1;
+        return r;
     }
-    return p;
-  }
+
+    static U3 R23(double t) {
+        U3 r{};
+        double c = std::cos(t), s = std::sin(t);
+        r[0][0] = 1;
+        r[1][1] = c;
+        r[1][2] = s;
+        r[2][1] = -s;
+        r[2][2] = c;
+        return r;
+    }
+
+    static U3 U13(double t, double d) {
+        U3 r{};
+        double c = std::cos(t), s = std::sin(t);
+        r[0][0] = c;
+        r[0][2] = std::exp(C(0, -d)) * s;
+        r[1][1] = 1;
+        r[2][0] = -std::exp(C(0, d)) * s;
+        r[2][2] = c;
+        return r;
+    }
+
+    static U3 mul(const U3 &a, const U3 &b) {
+        U3 r{};
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                r[i][j] = 0.0;
+                for (int k = 0; k < 3; ++k) {
+                    r[i][j] += a[i][k] * b[k][j];
+                }
+            }
+        }
+        return r;
+    }
+
+    static U3 build(double th12, double th23, double th13, double d) {
+        return mul(R23(th23), mul(U13(th13, d), R12(th12)));
+    }
 };
+
+struct PMNSVacuum {
+    using C = std::complex<double>;
+    using U3 = std::array<std::array<C, 3>, 3>;
+
+    explicit PMNSVacuum(PMNSParams p) : p_(p) {
+        U_ = PMNS::build(p_.th12, p_.th23, p_.th13, p_.delta);
+    }
+
+    double prob(int a, int b, double L, double E) const {
+        const double k = 1.267;
+        const double dm21 = p_.dm21;
+        const double dm31 = p_.dm31;
+        const double dm32 = dm31 - dm21;
+
+        const double D21 = k * dm21 * L / E;
+        const double D31 = k * dm31 * L / E;
+        const double D32 = k * dm32 * L / E;
+
+        auto term = [&](int i, int j) {
+            auto A = U_[a][i] * std::conj(U_[b][i]) * std::conj(U_[a][j]) * U_[b][j];
+            return std::make_pair(A.real(), A.imag());
+        };
+
+        double p = (a == b);
+
+        {
+            auto t31 = term(2, 0);
+            p += -4.0 * t31.first * std::sin(D31) * std::sin(D31)
+                 + 2.0 * t31.second * std::sin(2.0 * D31);
+
+            auto t32 = term(2, 1);
+            p += -4.0 * t32.first * std::sin(D32) * std::sin(D32)
+                 + 2.0 * t32.second * std::sin(2.0 * D32);
+
+            auto t21 = term(1, 0);
+            p += -4.0 * t21.first * std::sin(D21) * std::sin(D21)
+                 + 2.0 * t21.second * std::sin(2.0 * D21);
+        }
+
+        return p;
+    }
+
+    PMNSParams p_;
+    U3 U_;
+};
+

--- a/PlotStyle.h
+++ b/PlotStyle.h
@@ -1,10 +1,28 @@
 #pragma once
+
 #include <TStyle.h>
-inline void SetElegantStyle(){
-  static TStyle* s=nullptr; if(s){s->cd();return;} s=new TStyle("elegant","elegant");
-  s->SetCanvasColor(0); s->SetPadColor(0); s->SetFrameFillColor(0); s->SetFrameLineColor(1);
-  s->SetOptStat(0); s->SetOptTitle(0);
-  s->SetPadLeftMargin(0.12); s->SetPadRightMargin(0.05); s->SetPadBottomMargin(0.12); s->SetPadTopMargin(0.08);
-  s->SetLabelSize(0.04,"XY"); s->SetTitleSize(0.05,"XY"); s->SetTitleOffset(1.10,"X"); s->SetTitleOffset(1.10,"Y");
-  s->cd();
+
+inline void SetElegantStyle() {
+    static TStyle *s = nullptr;
+    if (s) {
+        s->cd();
+        return;
+    }
+
+    s = new TStyle("elegant", "elegant");
+    s->SetCanvasColor(0);
+    s->SetPadColor(0);
+    s->SetFrameFillColor(0);
+    s->SetFrameLineColor(1);
+    s->SetOptStat(0);
+    s->SetOptTitle(0);
+    s->SetPadLeftMargin(0.12);
+    s->SetPadRightMargin(0.05);
+    s->SetPadBottomMargin(0.12);
+    s->SetPadTopMargin(0.08);
+    s->SetLabelSize(0.04, "XY");
+    s->SetTitleSize(0.05, "XY");
+    s->SetTitleOffset(1.10, "X");
+    s->SetTitleOffset(1.10, "Y");
+    s->cd();
 }

--- a/plot_probability.cpp
+++ b/plot_probability.cpp
@@ -5,33 +5,75 @@
 #include <TAxis.h>
 #include <vector>
 #include <cmath>
-#include "RootStyle.h"
+#include <cstdlib>
+#include <iostream>
+
+#include "PlotStyle.h"
 #include "Oscillation.h"
 
-int main(){
-  SetElegantStyle();
-  double L=295.0; double E=0.6;
-  PMNSParams nh{0.5843,0.830,0.148,7.42e-5, 2.517e-3, 0.0};
-  PMNSParams ih{0.5843,0.830,0.148,7.42e-5,-2.498e-3, 0.0};
-  PMNSVacuum pmns_nh(nh), pmns_ih(ih);
-  int N=361; TGraph g_nh(N), g_ih(N);
-  for(int i=0;i<N;++i){
-    double d= i*M_PI/180.0; PMNSVacuum A_nh({nh.th12,nh.th23,nh.th13,nh.dm21,nh.dm31, d}); PMNSVacuum Abar_nh({nh.th12,nh.th23,nh.th13,nh.dm21,nh.dm31,-d});
-    double x = A_nh.prob(1,0,L,E); double y = Abar_nh.prob(1,0,L,E); g_nh.SetPoint(i,x,y);
-    PMNSVacuum A_ih({ih.th12,ih.th23,ih.th13,ih.dm21,ih.dm31, d}); PMNSVacuum Abar_ih({ih.th12,ih.th23,ih.th13,ih.dm21,ih.dm31,-d});
-    double xi = A_ih.prob(1,0,L,E); double yi = Abar_ih.prob(1,0,L,E); g_ih.SetPoint(i,xi,yi);
-  }
-  TCanvas c("c","",800,700);
-  g_nh.SetLineWidth(3); g_nh.SetLineColor(kBlue+1);
-  g_ih.SetLineWidth(3); g_ih.SetLineColor(kRed+1); g_ih.SetLineStyle(2);
-  g_nh.GetXaxis()->SetTitle("P(\n#nu_{#mu}\rightarrow\n#nu_{e})");
-  g_nh.GetYaxis()->SetTitle("P(\n#bar{#nu}_{#mu}\rightarrow\n#bar{#nu}_{e})");
-  g_nh.GetXaxis()->SetLimits(0.0,0.6); g_nh.GetYaxis()->SetRangeUser(0.0,0.6);
-  g_nh.Draw("AL"); g_ih.Draw("L SAME");
-  TLegend leg(0.58,0.74,0.88,0.89); leg.SetBorderSize(0); leg.SetFillStyle(0);
-  leg.AddEntry(&g_nh,"NH","l"); leg.AddEntry(&g_ih,"IH","l"); leg.Draw();
-  TLatex t; t.SetNDC(); t.SetTextSize(0.045);
-  t.DrawLatex(0.14,0.92,Form("L=%.0f km  E=%.1f GeV",L,E));
-  c.SaveAs("biprob.pdf"); c.SaveAs("biprob.png");
-  return 0;
+int main(int argc, char **argv) {
+    SetElegantStyle();
+
+    double L = 1300.0;
+    double E = 2.5;
+
+    if (argc > 1) {
+        L = std::atof(argv[1]);
+    }
+
+    if (argc > 2) {
+        E = std::atof(argv[2]);
+    }
+
+    PMNSParams nh{0.5843, 0.830, 0.148, 7.42e-5, 2.517e-3, 0.0};
+    PMNSParams ih{0.5843, 0.830, 0.148, 7.42e-5, -2.498e-3, 0.0};
+    PMNSVacuum pmns_nh(nh), pmns_ih(ih);
+
+    int N = 361;
+    TGraph g_nh(N), g_ih(N);
+    for (int i = 0; i < N; ++i) {
+        double d = i * M_PI / 180.0;
+        PMNSVacuum A_nh({nh.th12, nh.th23, nh.th13, nh.dm21, nh.dm31, d});
+        PMNSVacuum Abar_nh({nh.th12, nh.th23, nh.th13, nh.dm21, nh.dm31, -d});
+        double x = A_nh.prob(1, 0, L, E);
+        double y = Abar_nh.prob(1, 0, L, E);
+        g_nh.SetPoint(i, x, y);
+
+        PMNSVacuum A_ih({ih.th12, ih.th23, ih.th13, ih.dm21, ih.dm31, d});
+        PMNSVacuum Abar_ih({ih.th12, ih.th23, ih.th13, ih.dm21, ih.dm31, -d});
+        double xi = A_ih.prob(1, 0, L, E);
+        double yi = Abar_ih.prob(1, 0, L, E);
+        g_ih.SetPoint(i, xi, yi);
+    }
+
+    TCanvas c("c", "", 800, 700);
+    g_nh.SetLineWidth(3);
+    g_nh.SetLineColor(kBlue + 1);
+
+    g_ih.SetLineWidth(3);
+    g_ih.SetLineColor(kRed + 1);
+    g_ih.SetLineStyle(2);
+
+    g_nh.GetXaxis()->SetTitle("P(\n#nu_{#mu}\\rightarrow\n#nu_{e})");
+    g_nh.GetYaxis()->SetTitle("P(\n#bar{#nu}_{#mu}\\rightarrow\n#bar{#nu}_{e})");
+    g_nh.GetXaxis()->SetLimits(0.0, 0.6);
+    g_nh.GetYaxis()->SetRangeUser(0.0, 0.6);
+    g_nh.Draw("AL");
+    g_ih.Draw("L SAME");
+
+    TLegend leg(0.58, 0.74, 0.88, 0.89);
+    leg.SetBorderSize(0);
+    leg.SetFillStyle(0);
+    leg.AddEntry(&g_nh, "NH", "l");
+    leg.AddEntry(&g_ih, "IH", "l");
+    leg.Draw();
+
+    TLatex t;
+    t.SetNDC();
+    t.SetTextSize(0.045);
+    t.DrawLatex(0.14, 0.92, Form("L=%.0f km  E=%.1f GeV", L, E));
+
+    c.SaveAs("biprob.pdf");
+    c.SaveAs("biprob.png");
+    return 0;
 }


### PR DESCRIPTION
## Summary
- allow specifying baseline and neutrino energy on the command line with DUNE defaults

## Testing
- `mkdir build && cd build && cmake .. && cmake --build .` (ROOT package not found)


------
https://chatgpt.com/codex/tasks/task_e_68b78898c604832e85aeefc8b56c18be