### PR TITLE
Add suite of oscillation analysis plots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,24 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_executable(plot_probability plot_probability.cpp)
 target_include_directories(plot_probability PRIVATE ${ROOT_INCLUDE_DIRS})
 target_link_libraries(plot_probability ${ROOT_LIBRARIES})
+
+add_executable(plot_survival plot_survival.cpp)
+target_include_directories(plot_survival PRIVATE ${ROOT_INCLUDE_DIRS})
+target_link_libraries(plot_survival ${ROOT_LIBRARIES})
+
+add_executable(plot_mixing plot_mixing.cpp)
+target_include_directories(plot_mixing PRIVATE ${ROOT_INCLUDE_DIRS})
+target_link_libraries(plot_mixing ${ROOT_LIBRARIES})
+
+add_executable(plot_cp plot_cp.cpp)
+target_include_directories(plot_cp PRIVATE ${ROOT_INCLUDE_DIRS})
+target_link_libraries(plot_cp ${ROOT_LIBRARIES})
+
+add_executable(plot_baseline plot_baseline.cpp)
+target_include_directories(plot_baseline PRIVATE ${ROOT_INCLUDE_DIRS})
+target_link_libraries(plot_baseline ${ROOT_LIBRARIES})
+
+add_executable(plot_matter plot_matter.cpp)
+target_include_directories(plot_matter PRIVATE ${ROOT_INCLUDE_DIRS})
+target_link_libraries(plot_matter ${ROOT_LIBRARIES})
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Oscillation Analysis Plots
+
+## plot_survival
+Two-flavor survival probability versus $L/E$ inspired by Pontecorvo (1957) and Maki–Nakagawa–Sakata (1962).
+
+## plot_mixing
+Appearance probability scan in $\theta_{13}$ following early mixing studies after Cabibbo (1963).
+
+## plot_cp
+Appearance probability as a function of $\delta_{CP}$ echoing CP violation work by Kobayashi and Maskawa (1973).
+
+## plot_baseline
+Energy-dependent appearance probabilities for T2K, NOνA, and DUNE baselines highlighted in their design papers.
+
+## plot_matter
+Vacuum and matter probabilities showcasing the MSW effect formulated by Wolfenstein (1978) and Mikheyev–Smirnov (1985).
+

--- a/plot_baseline.cpp
+++ b/plot_baseline.cpp
@@ -1,0 +1,49 @@
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TLegend.h>
+#include <TAxis.h>
+#include <vector>
+#include <cmath>
+#include <string>
+#include "PlotStyle.h"
+#include "Oscillation.h"
+
+int main() {
+    SetElegantStyle();
+    std::vector<double> baselines = {295.0, 810.0, 1300.0};
+    std::vector<std::string> labels = {"T2K", "NO#nuA", "DUNE"};
+    PMNSParams nh{0.5843, 0.830, 0.148, 7.42e-5, 2.517e-3, 0.0};
+    int N = 200;
+    std::vector<TGraph> graphs;
+    for (size_t j = 0; j < baselines.size(); ++j) {
+        graphs.emplace_back(N);
+        for (int i = 0; i < N; ++i) {
+            double E = 0.2 + 0.03 * i;
+            PMNSVacuum pmns(nh);
+            double p = pmns.prob(1, 0, baselines[j], E);
+            graphs.back().SetPoint(i, E, p);
+        }
+    }
+    TCanvas c("base", "", 800, 600);
+    int colors[3] = {kBlue + 1, kRed + 1, kGreen + 2};
+    TLegend leg(0.55, 0.65, 0.88, 0.85);
+    leg.SetBorderSize(0);
+    leg.SetFillStyle(0);
+    for (size_t j = 0; j < graphs.size(); ++j) {
+        graphs[j].SetLineWidth(2);
+        graphs[j].SetLineColor(colors[j]);
+        if (j == 0) {
+            graphs[j].GetXaxis()->SetTitle("E [GeV]");
+            graphs[j].GetYaxis()->SetTitle("P(#nu_{#mu}#rightarrow#nu_{e})");
+            graphs[j].GetYaxis()->SetRangeUser(0.0, 0.2);
+            graphs[j].Draw("AL");
+        } else {
+            graphs[j].Draw("L SAME");
+        }
+        leg.AddEntry(&graphs[j], labels[j].c_str(), "l");
+    }
+    leg.Draw();
+    c.SaveAs("baseline_scan.pdf");
+    return 0;
+}
+

--- a/plot_cp.cpp
+++ b/plot_cp.cpp
@@ -1,0 +1,32 @@
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TAxis.h>
+#include <vector>
+#include <cmath>
+#include "PlotStyle.h"
+#include "Oscillation.h"
+
+int main() {
+    SetElegantStyle();
+    double L = 1300.0;
+    double E = 2.5;
+    PMNSParams nh{0.5843, 0.830, 0.148, 7.42e-5, 2.517e-3, 0.0};
+    int N = 361;
+    TGraph g(N);
+    for (int i = 0; i < N; ++i) {
+        double d = i * M_PI / 180.0;
+        PMNSVacuum pmns({nh.th12, nh.th23, nh.th13, nh.dm21, nh.dm31, d});
+        double p = pmns.prob(1, 0, L, E);
+        g.SetPoint(i, d, p);
+    }
+    TCanvas c("cp", "", 800, 600);
+    g.SetLineWidth(2);
+    g.GetXaxis()->SetTitle("#delta_{CP} [rad]");
+    g.GetYaxis()->SetTitle("P(#nu_{#mu}#rightarrow#nu_{e})");
+    g.GetXaxis()->SetLimits(0, 2 * M_PI);
+    g.GetYaxis()->SetRangeUser(0.0, 0.2);
+    g.Draw("AL");
+    c.SaveAs("cp_phase.pdf");
+    return 0;
+}
+

--- a/plot_matter.cpp
+++ b/plot_matter.cpp
@@ -1,0 +1,54 @@
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TLegend.h>
+#include <TAxis.h>
+#include <vector>
+#include <cmath>
+#include "PlotStyle.h"
+#include "Oscillation.h"
+
+int main() {
+    SetElegantStyle();
+    double L = 1300.0;
+    double rho = 3.0;
+    double Ye = 0.5;
+    double dm2 = 2.5e-3;
+    double th = 0.148;
+    int N = 200;
+    TGraph g_vac(N), g_mat(N);
+    for (int i = 0; i < N; ++i) {
+        double E = 0.2 + 0.03 * i;
+        double x = 1.267 * dm2 * L / E;
+        double pvac = std::pow(std::sin(2 * th), 2) * std::pow(std::sin(x), 2);
+        g_vac.SetPoint(i, E, pvac);
+        double A = 1.52e-4 * rho * Ye * E;
+        double cos2 = std::cos(2 * th);
+        double sin2 = std::sin(2 * th);
+        double denom = std::sqrt(std::pow(cos2 - A / dm2, 2) + sin2 * sin2);
+        double thm = 0.5 * std::atan2(sin2, cos2 - A / dm2);
+        double dm2m = dm2 * denom;
+        double xm = 1.267 * dm2m * L / E;
+        double pm = std::pow(std::sin(2 * thm), 2) * std::pow(std::sin(xm), 2);
+        g_mat.SetPoint(i, E, pm);
+    }
+    TCanvas c("matter", "", 800, 600);
+    g_vac.SetLineWidth(2);
+    g_mat.SetLineWidth(2);
+    g_vac.SetLineColor(kBlue + 1);
+    g_mat.SetLineColor(kRed + 1);
+    g_mat.SetLineStyle(2);
+    g_vac.GetXaxis()->SetTitle("E [GeV]");
+    g_vac.GetYaxis()->SetTitle("P_{2flavor}(#nu_{e}#rightarrow#nu_{#mu})");
+    g_vac.GetYaxis()->SetRangeUser(0.0, 0.2);
+    g_vac.Draw("AL");
+    g_mat.Draw("L SAME");
+    TLegend leg(0.55, 0.65, 0.88, 0.85);
+    leg.SetBorderSize(0);
+    leg.SetFillStyle(0);
+    leg.AddEntry(&g_vac, "Vacuum", "l");
+    leg.AddEntry(&g_mat, "Matter", "l");
+    leg.Draw();
+    c.SaveAs("matter_effect.pdf");
+    return 0;
+}
+

--- a/plot_mixing.cpp
+++ b/plot_mixing.cpp
@@ -1,0 +1,31 @@
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TAxis.h>
+#include <vector>
+#include <cmath>
+#include "PlotStyle.h"
+#include "Oscillation.h"
+
+int main() {
+    SetElegantStyle();
+    double L = 1300.0;
+    double E = 2.5;
+    PMNSParams base{0.5843, 0.830, 0.0, 7.42e-5, 2.517e-3, 0.0};
+    int N = 180;
+    TGraph g(N);
+    for (int i = 0; i < N; ++i) {
+        double th13 = i * M_PI / (2.0 * N);
+        PMNSVacuum pmns({base.th12, base.th23, th13, base.dm21, base.dm31, base.delta});
+        double p = pmns.prob(1, 0, L, E);
+        g.SetPoint(i, th13, p);
+    }
+    TCanvas c("mix", "", 800, 600);
+    g.SetLineWidth(2);
+    g.GetXaxis()->SetTitle("#theta_{13} [rad]");
+    g.GetYaxis()->SetTitle("P(#nu_{#mu}#rightarrow#nu_{e})");
+    g.GetYaxis()->SetRangeUser(0.0, 0.2);
+    g.Draw("AL");
+    c.SaveAs("mixing_angle_scan.pdf");
+    return 0;
+}
+

--- a/plot_survival.cpp
+++ b/plot_survival.cpp
@@ -1,0 +1,31 @@
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TAxis.h>
+#include <vector>
+#include <cmath>
+#include "PlotStyle.h"
+#include "Oscillation.h"
+
+int main() {
+    SetElegantStyle();
+    double dm2 = 2.5e-3;
+    double theta = 0.8;
+    double s2 = std::pow(std::sin(2 * theta), 2);
+    int N = 500;
+    TGraph g(N);
+    for (int i = 0; i < N; ++i) {
+        double LE = i * 4.0;
+        double x = 1.267 * dm2 * LE;
+        double p = 1 - s2 * std::pow(std::sin(x), 2);
+        g.SetPoint(i, LE, p);
+    }
+    TCanvas c("surv", "", 800, 600);
+    g.SetLineWidth(2);
+    g.GetXaxis()->SetTitle("L/E [km/GeV]");
+    g.GetYaxis()->SetTitle("P(#nu_{#mu}#rightarrow#nu_{#mu})");
+    g.GetYaxis()->SetRangeUser(0.0, 1.0);
+    g.Draw("AL");
+    c.SaveAs("survival_LE.pdf");
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Split multi-plot driver into standalone programs for survival, mixing-angle, CP-phase, baseline, and matter-effect probabilities
- Document historical inspiration for each plot in README

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "ROOT")*
- `apt-get install -y root-system` *(fails: Package 'root-system' has no installation candidate)*
- `apt-get install -y root-system-bin` *(fails: Package 'root-system-bin' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68b78d630c5c832eb27df81159c93244