### PR TITLE
docs: add build and run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Oscillation Analysis Plots
 
+## Build and Run
+
+To build and run any of the plotting executables (for example, `plot_survival`), execute:
+
+```bash
+cmake -S . -B build
+cmake --build build --target plot_survival
+./build/plot_survival
+```
+
+Replace `plot_survival` with another target such as `plot_mixing`, `plot_cp`, or `plot_matter` to generate different plots.
+
 ## plot_survival
 Two-flavor survival probability versus $L/E$ inspired by Pontecorvo (1957) and Maki–Nakagawa–Sakata (1962).
 


### PR DESCRIPTION
## Summary
- document how to build and run plotting executables with CMake

## Testing
- `cmake -S . -B build && cmake --build build --target plot_survival` *(fails: Could not find a package configuration file provided by "ROOT")*


------
https://chatgpt.com/codex/tasks/task_e_68b79344d024832ea3451ff8cf413773